### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/AutoGen_Panel/requirements.txt
+++ b/AutoGen_Panel/requirements.txt
@@ -1,4 +1,4 @@
-pyautogen[retrievechat,mathchat,lmm]~=0.2.0b6
+ag2[retrievechat,mathchat,lmm]~=0.2.0b6
 panel>=1.3.1
 cloudpickle
 diskcache

--- a/Tasks4AutoGen/snake_game.py
+++ b/Tasks4AutoGen/snake_game.py
@@ -1,6 +1,6 @@
 """
 AutoGen Code:
-    # pip install pyautogen
+    # pip install ag2
 
     from autogen import AssistantAgent, UserProxyAgent, config_list_from_json
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
